### PR TITLE
Fix typo in dynamics example

### DIFF
--- a/src/Features/pages/Dynamics.qml
+++ b/src/Features/pages/Dynamics.qml
@@ -12,7 +12,7 @@ ScrollablePage {
             width: parent.width
             wrapMode: Label.Wrap
             horizontalAlignment: Qt.AlignHCenter
-            text: 'Mutable JS objects can be sent to .NET to be interacted with, using the ""dyamic"" type'
+            text: 'Mutable JS objects can be sent to .NET to be interacted with, using the ""dynamic"" type'
         }
 
         Button {


### PR DESCRIPTION
Wouldn't normally open a PR for a single typo, but since it's in the UI it really bothered me. 

I did a once over of the other examples and didn't find any others.