### PR TITLE
Use Qml type instead of QQmlApplicationEngine.

### DIFF
--- a/src/Features/Program.cs
+++ b/src/Features/Program.cs
@@ -14,13 +14,13 @@ namespace Features
             {
                 using (var qmlEngine = new QQmlApplicationEngine())
                 {
-                    QQmlApplicationEngine.RegisterType<SignalsModel>("Features");
-                    QQmlApplicationEngine.RegisterType<NotifySignalsModel>("Features");
-                    QQmlApplicationEngine.RegisterType<AsyncAwaitModel>("Features");
-                    QQmlApplicationEngine.RegisterType<NetObjectsModel>("Features");
-                    QQmlApplicationEngine.RegisterType<DynamicModel>("Features");
-                    QQmlApplicationEngine.RegisterType<CalculatorModel>("Features");
-                    QQmlApplicationEngine.RegisterType<CollectionsModel>("Features");
+                    Qml.RegisterType<SignalsModel>("Features");
+                    Qml.RegisterType<NotifySignalsModel>("Features");
+                    Qml.RegisterType<AsyncAwaitModel>("Features");
+                    Qml.RegisterType<NetObjectsModel>("Features");
+                    Qml.RegisterType<DynamicModel>("Features");
+                    Qml.RegisterType<CalculatorModel>("Features");
+                    Qml.RegisterType<CollectionsModel>("Features");
 
                     qmlEngine.Load("Main.qml");
                     


### PR DESCRIPTION
Solves: https://github.com/pauldotknopf/Qml.Net.Examples/issues/4

Should wait until `Qml` is available from the NuGet package.