### PR TITLE
Downgraded Qml.Net.OSXBinaries to version 0.6.1.

### DIFF
--- a/src/Features/Features.csproj
+++ b/src/Features/Features.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Qml.Net" Version="0.6.2" />
     <PackageReference Include="Qml.Net.LinuxBinaries" Version="0.6.2" />
-    <PackageReference Include="Qml.Net.OSXBinaries" Version="0.6.2" />
+    <PackageReference Include="Qml.Net.OSXBinaries" Version="0.6.1" />
     <PackageReference Include="Qml.Net.WindowsBinaries" Version="0.6.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There is no 0.6.2. version for the OSXBinaries NuGet package yet.